### PR TITLE
Update tool deps and fix a warn

### DIFF
--- a/Gem/Code/Source/NetSoakTestSystemComponent.cpp
+++ b/Gem/Code/Source/NetSoakTestSystemComponent.cpp
@@ -124,7 +124,7 @@ namespace NetSoakTest
 
     void NetSoakTestSystemComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
-        AZ::TimeMs elapsedMs = aznumeric_cast<AZ::TimeMs>(aznumeric_cast<int64_t>(deltaTime / 1000.0f));
+        [[maybe_unused]] AZ::TimeMs elapsedMs = aznumeric_cast<AZ::TimeMs>(aznumeric_cast<int64_t>(deltaTime / 1000.0f));
 
         NetSoakTestPackets::Small packet;
 

--- a/Gem/Code/tool_dependencies.cmake
+++ b/Gem/Code/tool_dependencies.cmake
@@ -16,8 +16,7 @@ set(GEM_DEPENDENCIES
     Gem::LyShine.Editor
     Gem::Maestro.Editor
     Gem::SceneProcessing.Editor
-    Gem::ImageProcessing.Editor
     Gem::LmbrCentral.Editor
-    Gem::TextureAtlas
+    Gem::TextureAtlas.Editor
     Gem::Camera.Editor
 )


### PR DESCRIPTION
Removing a now non-existent Gem and accounting for updates to TextureAtlas. Also fixing a warn.