### PR TITLE
Update gem manifest per current gem definition requirements

### DIFF
--- a/Gem/gem.json
+++ b/Gem/gem.json
@@ -1,10 +1,21 @@
 {
-    "GemFormatVersion": 4,
-    "Uuid": "5111dee500ed4812a7905093a73d3837",
-    "Name": "NetSoakTest",
-    "DisplayName": "NetSoakTest",
-    "Summary": "NetSoakTest Project Gem. Indefinitely tests AzNetworking transport via loopback.",
-    "Tags": ["Game"],
-    "IconPath": "preview.png",
-    "IsGameGem": true
+    "gem_name": "NetSoakTest",
+    "display_name": "NetSoakTest",
+    "licence": "Apache-2.0 or MIT",
+    "license_url": "https://github.com/o3de/o3de-netsoaktest/blob/development/LICENSE.txt",
+    "origin": "",
+    "origin_url": "https://github.com/o3de/o3de-netsoaktest",
+    "type": "",
+    "summary": "NetSoakTest Project Gem. Indefinitely tests AzNetworking transport via loopback.",
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [
+        "NetSoakTest"
+    ],
+    "icon_path": "preview.png",
+    "requirements": "",
+    "documentation_url": "",
+    "dependencies": [
+    ]
 }


### PR DESCRIPTION
Updates `gem.json` field names to align with current gem definition requirements & to avoid cmake errors. 
See  https://github.com/o3de/o3de-multiplayersample/pull/124 for equivalent update in [o3de-multiplayersample](https://github.com/o3de/o3de-multiplayersample).

### Testing

prior to change, CMAKE produces an error on configuration:
```ps
~\source\o3de-netsoaktest> cmake -S . -B build -G "Visual Studio 16 2019" -DLY_3RDPARTY_PATH="C:\Users\USER\.o3de\3rdParty"

-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.19042.
-- Using package C:/Users/USER/.o3de/3rdParty/packages/zlib-1.2.11-rev5-windows
-- Using package C:/Users/USER/.o3de/3rdParty/packages/qt-5.15.2-rev7-windows
........ [additional log lines omitted for brevity]........
CMake Error at C:/Users/USER/source/o3de/cmake/O3DEJson.cmake:54 (message):
  Error reading field at key gem_name in file
  "C:/Users/USER/source/o3de-netsoaktest/Gem/gem.json" : member 'gem_name'
  not found
Call Stack (most recent call first):
  C:/Users/USER/source/o3de/cmake/SettingsRegistry.cmake:158 (o3de_read_json_key)
  C:/Users/USER/source/o3de/cmake/SettingsRegistry.cmake:183 (ly_get_gem_module_root)
  C:/Users/USER/source/o3de/cmake/SettingsRegistry.cmake:266 (ly_populate_gem_objects)
  C:/Users/USER/source/o3de/CMakeLists.txt:97 (ly_delayed_generate_settings_registry)


-- Configuring incomplete, errors occurred!

```

post-change, CMAKE configuration succeeds.
```ps
~\source\o3de-netsoaktest> cmake -S . -B build -G "Visual Studio 16 2019" -DLY_3RDPARTY_PATH="C:\Users\USER\.o3de\3rdParty"

-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.19042.
-- Using package C:/Users/USER/.o3de/3rdParty/packages/zlib-1.2.11-rev5-windows
-- Using package C:/Users/USER/.o3de/3rdParty/packages/qt-5.15.2-rev7-windows
........ [additional log lines omitted for brevity]........
-- Using package C:/Users/USER/.o3de/3rdParty/packages/civetweb-1.8-rev1-windows
-- Using package C:/Users/USER/.o3de/3rdParty/packages/OpenMesh-8.1-rev3-windows
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/USER/source/o3de-netsoaktest/build
```