### PR TITLE
Fix teardown access violation in NetSoakTestSystemComponent

### DIFF
--- a/Gem/Code/Source/NetSoakTestSystemComponent.cpp
+++ b/Gem/Code/Source/NetSoakTestSystemComponent.cpp
@@ -169,6 +169,9 @@ namespace NetSoakTest
     {
         AZ::TickBus::Handler::BusDisconnect();
         NetSoakTestRequestBus::Handler::BusDisconnect();
+
+        AZ::Interface<INetworking>::Get()->DestroyNetworkInterface(AZ::Name(s_loopbackInterfaceName));
+        AZ::Interface<INetworking>::Get()->DestroyNetworkInterface(AZ::Name(s_networkInterfaceName));
     }
 
     void NetSoakTestSystemComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)


### PR DESCRIPTION
Adding missing DestroyNetworkInterface calls. This fixes an access violation where the network interfaces attempt to access their connection listener at destruction time.

Signed-off-by: puvvadar <puvvadar@amazon.com>