### PR TITLE
Fix the netsoaktest build failure due to the latest AzCore changes

### DIFF
--- a/Gem/Code/Source/NetSoakTestSystemComponent.cpp
+++ b/Gem/Code/Source/NetSoakTestSystemComponent.cpp
@@ -29,14 +29,12 @@ namespace AzNetworking
 
 namespace AZ::ConsoleTypeHelpers
 {
-    template <>
     inline CVarFixedString ValueToString(const AzNetworking::ProtocolType& value)
     {
         return (value == AzNetworking::ProtocolType::Tcp) ? "tcp" : "udp";
     }
 
-    template <>
-    inline bool StringSetToValue<AzNetworking::ProtocolType>(AzNetworking::ProtocolType& outValue, const ConsoleCommandContainer& arguments)
+    inline bool StringSetToValue(AzNetworking::ProtocolType& outValue, const ConsoleCommandContainer& arguments)
     {
         if (!arguments.empty())
         {
@@ -54,7 +52,6 @@ namespace AZ::ConsoleTypeHelpers
         return false;
     }
 
-    template <>
     inline CVarFixedString ValueToString(const AzNetworking::SoakMode& value)
     {
         if (value == AzNetworking::SoakMode::Client)
@@ -68,8 +65,7 @@ namespace AZ::ConsoleTypeHelpers
         return "loopback";
     }
 
-    template <>
-    inline bool StringSetToValue<AzNetworking::SoakMode>(AzNetworking::SoakMode& outValue, const ConsoleCommandContainer& arguments)
+    inline bool StringSetToValue(AzNetworking::SoakMode& outValue, const ConsoleCommandContainer& arguments)
     {
         if (!arguments.empty())
         {


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

The netsoaktest project failed to build on Windows and Linux due to one of the latest changes in dev: https://github.com/o3de/o3de/pull/10383. This PR applies the same changes to the netsoaktest project as the Multiplayer gem (https://github.com/o3de/o3de/pull/10383/files#diff-28d5affdbead3392b99c090eaf9a0f759fb2afe73429b3634e7e943b15ed3c00) to fix the build failure.